### PR TITLE
Fix wrong filePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function (opt) {
 
     //compile locals async
     try {
-      var filePath = file.base;
+      var filePath = path.dirname(file.path);
       var fileCwd = file.cwd;
       var fileName = gutil.replaceExtension(path.basename(file.path), "");
 


### PR DESCRIPTION
Hi, could you merge my commit?
When finding files in nested directory by using glob pattern, the file path is wrong and it doesn't work correctly. So I changed to use `path.dirname` method for getting `filePath`.
Thank you.
